### PR TITLE
Allow series and parallel reducer topologies

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,8 +14,10 @@ import {
 
 import {
 	Action,
+	combineInParallel,
 	createAction,
 	createStore,
+	createStore2,
 	Dispatch,
 	Store,
 } from './store.js'
@@ -56,12 +58,19 @@ canvas.width = parseInt(canvasWidth, 10)
 // 	rocket: Rocket
 // 	settings: Settings
 // }
-const [store, dispatch, notify] = createStore({
+// const [store, dispatch, notify] = createStore({
+// 	asteroids,
+// 	controls,
+// 	rocket,
+// 	settings,
+// })
+const rootReducer = combineInParallel({
 	asteroids,
 	controls,
 	rocket,
 	settings,
 })
+const [getState, dispatch, notify] = createStore2(rootReducer)
 ////////////////////////////////////////////////////////////////////////////////
 
 // "hardware" //////////////////////////////////////////////////////////////////
@@ -74,9 +83,6 @@ enum KEYS {
 }
 
 function onKeyDown (event: KeyboardEvent): void {
-console.log('event.keyCode', event.keyCode)
-	const { direction } = store.controls
-
 	switch( event.keyCode ) {
 		case KEYS.LEFT:
 			dispatch( setDirection( Directions.LEFT ) )
@@ -128,7 +134,8 @@ radios.addEventListener('click', event => {
 })
 
 function updateSpeedView (store: Store) {
-	const { speed } = store.settings
+	// const { speed } = store.settings
+	const { settings: { speed } } = getState()
 	const radios = document.querySelectorAll(`[type="radio"]`)
 
 	Array.prototype.forEach.call(radios, (radio: HTMLInputElement) => {
@@ -145,7 +152,7 @@ notify(updateSpeedView, false)
 
 
 // game loop ///////////////////////////////////////////////////////////////////
-let clearRestartNotifier: Function | null
+let clearRestartNotifier: Function | null = null
 function restartDraw (store: Store): void {
 	if(!(store.settings.speed === Speeds.Still)) {
 		draw(true)
@@ -158,11 +165,12 @@ function restartDraw (store: Store): void {
 
 dispatch( initialise() )
 
+const store = getState()
 console.log(`initialised`, store)
 
 function draw (shouldLog?: boolean): void {
+	const store = getState()
 	shouldLog && console.log(`draw() - store`, store)
-
 	animate( context, store, dispatch )
 
 	switch( store.settings.speed ) {

--- a/src/store.spec.ts
+++ b/src/store.spec.ts
@@ -1,0 +1,54 @@
+import {
+	Action,
+	combineInSeries,
+} from './store'
+
+function generateOne (state: number, action: Action ) {
+	return 1
+}
+
+function addOne (state: number, action: Action ) {
+	return state + 1
+}
+
+function subtractOne (state: number, action: Action ) {
+	return state - 1
+}
+
+const mockAction = { type: 'TEST/MOCK_ACTION' }
+
+test('retured reducer applies source reducers in series', () => {
+	const hopefullyInSeries = combineInSeries( generateOne, addOne )
+
+	expect(hopefullyInSeries(42, mockAction)).toEqual(2)
+})
+
+test('returned reducer permits modifying state from a given start state', () => {
+	const hopefullyInSeries = combineInSeries( addOne, addOne )
+
+	expect(hopefullyInSeries(42, mockAction)).toEqual(44)
+})
+
+test('returned reducer works for arbitrary number of reducers', () => {
+	const hopefullyInSeries = combineInSeries(
+		addOne,
+		addOne,
+		addOne,
+		addOne,
+		addOne,
+		addOne,
+		addOne,
+		addOne,
+		addOne,
+	)
+
+	expect(hopefullyInSeries(42, mockAction)).toEqual(51)
+})
+
+test('returned reducer operates on arbitrary reducers', () => {
+	const hopefullyInSeries = combineInSeries( addOne, subtractOne, addOne, subtractOne )
+
+	expect(hopefullyInSeries(42, mockAction)).toEqual(42)
+})
+
+

--- a/src/store.spec.ts
+++ b/src/store.spec.ts
@@ -151,17 +151,19 @@ describe('combineInParallel', () => {
 	})
 })
 
-describe.only('getState', () => {
-	test('returns the current state', () => {
+describe('createStore2', () => {
+	test('applies the reducer to generate initial state', () => {
 		const [getState] = createStore2(addOrSubtractOne) 
 		expect(getState()).toEqual(0)
 	})
-})
 
-describe('dispatch', () => {
-	
-})
+	test('maintains state', () => {
+		const [getState, dispatch] = createStore2(addOrSubtractOne) 
+		const add = { type: 'TEST/ADD' }
 
-describe('notify', () => {
-	
+		dispatch(add)
+		dispatch(add)
+
+		expect(getState()).toEqual(2)
+	})
 })

--- a/src/store.spec.ts
+++ b/src/store.spec.ts
@@ -2,6 +2,7 @@ import {
 	Action,
 	combineInParallel,
 	combineInSeries,
+	createStore2,
 	Mapable,
 } from './store'
 
@@ -148,4 +149,19 @@ describe('combineInParallel', () => {
 			someCounter: 42,
 		})
 	})
+})
+
+describe.only('getState', () => {
+	test('returns the current state', () => {
+		const [getState] = createStore2(addOrSubtractOne) 
+		expect(getState()).toEqual(0)
+	})
+})
+
+describe('dispatch', () => {
+	
+})
+
+describe('notify', () => {
+	
 })

--- a/src/store.spec.ts
+++ b/src/store.spec.ts
@@ -15,40 +15,72 @@ function subtractOne (state: number, action: Action ) {
 	return state - 1
 }
 
+function addOrSubtractOne (state: number, action: Action ) {
+	switch (action.type) {
+		case 'TEST/ADD':
+			return state + 1
+		case 'TEST/SUBTRACT':
+			return state - 1
+		default:
+			return state
+	}
+}
+
 const mockAction = { type: 'TEST/MOCK_ACTION' }
 
-test('retured reducer applies source reducers in series', () => {
-	const hopefullyInSeries = combineInSeries( generateOne, addOne )
+describe('combineInSeries', () => {
+	test('retured reducer applies source reducers in series', () => {
+		const hopefullyInSeries = combineInSeries( generateOne, addOne )
 
-	expect(hopefullyInSeries(42, mockAction)).toEqual(2)
-})
+		expect(hopefullyInSeries(42, mockAction)).toEqual(2)
+	})
 
-test('returned reducer permits modifying state from a given start state', () => {
-	const hopefullyInSeries = combineInSeries( addOne, addOne )
+	test('returned reducer calls each reducer with state from the previous one', () => {
+		const hopefullyInSeries = combineInSeries( addOne, addOne )
 
-	expect(hopefullyInSeries(42, mockAction)).toEqual(44)
-})
+		expect(hopefullyInSeries(42, mockAction)).toEqual(44)
+	})
 
-test('returned reducer works for arbitrary number of reducers', () => {
-	const hopefullyInSeries = combineInSeries(
-		addOne,
-		addOne,
-		addOne,
-		addOne,
-		addOne,
-		addOne,
-		addOne,
-		addOne,
-		addOne,
-	)
+	test('returned reducer works for arbitrary number of reducers', () => {
+		const hopefullyInSeries = combineInSeries(
+			addOne,
+			addOne,
+			addOne,
+			addOne,
+			addOne,
+			addOne,
+			addOne,
+			addOne,
+			addOne,
+		)
 
-	expect(hopefullyInSeries(42, mockAction)).toEqual(51)
-})
+		expect(hopefullyInSeries(33, mockAction)).toEqual(42)
+	})
 
-test('returned reducer operates on arbitrary reducers', () => {
-	const hopefullyInSeries = combineInSeries( addOne, subtractOne, addOne, subtractOne )
+	test('returned reducer operates on arbitrary reducers', () => {
+		const hopefullyInSeries = combineInSeries(
+			addOne,
+			subtractOne,
+			addOne,
+			subtractOne,
+			generateOne,
+		)
 
-	expect(hopefullyInSeries(42, mockAction)).toEqual(42)
+		expect(hopefullyInSeries(42, mockAction)).toEqual(1)
+	})
+
+	test('returned reducer calls each supplied reducer with the previous state and the action', () => {
+		const hopefullyInSeries = combineInSeries(
+			generateOne,
+			addOne,
+			subtractOne,
+			addOrSubtractOne,
+			addOrSubtractOne,
+		)
+		const add = { type: 'TEST/ADD' }
+
+		expect(hopefullyInSeries(42, add)).toEqual(3)
+	})
 })
 
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -3,34 +3,26 @@ export interface Action {
 	type: string
 }
 
-export interface ActionT {
-	payload?: any
-	type: Enumerator
-}
-
-export interface Dispatch {
-	( a: Action ): void
-}
-
-export interface Notify {
-	( f: Function, b?: boolean ): ClearNotification
-}
-
-export interface ClearNotification {
-	(): void
-}
+// export interface ActionT<U> {
+// 	payload?: any
+// 	type: U
+// }
 
 export interface Reducer<T> {
 	( state: T, action: Action ): T
 }
 
+// export interface Reducer<T, U> {
+// 	( state: T, action: ActionT<U> ): T
+// }
+
 export interface ReducerMap {
 	[ key: string ]: Reducer<any>
 }
 
-export interface Selector<T> {
-	( s: Store ): T
-}
+// export interface Selector<T> {
+// 	( s: Store ): T
+// }
 
 interface Mapable {
 	[ key: string ]: any
@@ -81,12 +73,25 @@ function combineInSeries (...reducers: Reducer<any>[] ): Reducer<any> {
 	}
 }
 
-interface GetState {
+// create the store, get the helpers ///////////////////////////////////////////
+export interface ClearNotification {
+	(): void
+}
+
+export interface Dispatch {
+	( a: Action ): void
+}
+
+export interface GetState {
 	(): Store
 }
 
-interface Listener {
+export interface Listener {
 	(s: Store): void
+}
+
+export interface Notify {
+	( f: Function, b?: boolean ): ClearNotification
 }
 
 export function createStore2 (
@@ -130,6 +135,7 @@ export function createStore2 (
 
 	return [getState, dispatch, notify]
 }
+////////////////////////////////////////////////////////////////////////////////
 
 // naive `composeReducers`/`useReducer`
 export function createStore (

--- a/src/store.ts
+++ b/src/store.ts
@@ -9,7 +9,7 @@ export interface Action {
 // }
 
 export interface Reducer<T> {
-	( state: T, action: Action ): T
+	( state: T | undefined, action: Action ): T
 }
 
 // export interface Reducer<T, U> {
@@ -24,7 +24,7 @@ export interface ReducerMap {
 // 	( s: Store ): T
 // }
 
-interface Mapable {
+export interface Mapable {
 	[ key: string ]: any
 }
 
@@ -40,10 +40,8 @@ export function createAction ( type: string ): Function {
 	}
 }
 
-function combineInParallel (
-	reducerMap: ReducerMap
-): Reducer<ReducerMap> {
-	return function reduceInParallel ( state: Mapable, action: Action ): ReducerMap {
+export function combineInParallel ( reducerMap: ReducerMap ): Reducer<ReducerMap> {
+	return function reduceInParallel (state: Mapable = {}, action: Action ): Mapable {
 		const sliceNames = Object.keys(reducerMap)
 
 		function createSlices (state: Mapable, sliceName: string): Mapable {

--- a/src/store.ts
+++ b/src/store.ts
@@ -46,7 +46,7 @@ function combineInParallel (
 	return function reduceInParallel ( state: Mapable, action: Action ): ReducerMap {
 		const sliceNames = Object.keys(reducerMap)
 
-		function reduceSlices (state: Mapable, sliceName: string): Mapable {
+		function createSlices (state: Mapable, sliceName: string): Mapable {
 			const sliceState = state[sliceName]
 			const reducer = reducerMap[sliceName]
 			const nextSliceState = reducer(sliceState, action)
@@ -59,17 +59,17 @@ function combineInParallel (
 			}
 		}
 
-		return sliceNames.reduce(reduceSlices, state)
+		return sliceNames.reduce(createSlices, state)
 	}
 }
 
-function combineInSeries (...reducers: Reducer<any>[] ): Reducer<any> {
-	return function reduceInSeries ( state: Store, action: Action ): Store {
-		function reduceReducers (state: Store, reducer: Reducer<any>) {
+export function combineInSeries (...reducers: Reducer<any>[] ): Reducer<any> {
+	return function reduceSequencially ( state: Store, action: Action ): Store {
+		function serialCombine (state: Store, reducer: Reducer<any>) {
 			return reducer(state, action)
 		}
 
-		return reducers.reduce(reduceReducers, state)
+		return reducers.reduce(serialCombine, state)
 	}
 }
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -131,6 +131,8 @@ export function createStore2 (
 		}
 	}
 
+	const init: Action = { type: 'STORE/INITIALISE' }
+	dispatch(init)
 	return [getState, dispatch, notify]
 }
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/store.ts
+++ b/src/store.ts
@@ -32,9 +32,12 @@ export interface Selector<T> {
 	( s: Store ): T
 }
 
-export interface Store {
+interface Mapable {
 	[ key: string ]: any
 }
+
+export type Store = Mapable
+// export type Store = number | string | Array<any> | Mapable
 
 export function createAction ( type: string ): Function {
 	return function ( payload?: any ): Action {
@@ -45,17 +48,100 @@ export function createAction ( type: string ): Function {
 	}
 }
 
+function combineInParallel (
+	reducerMap: ReducerMap
+): Reducer<ReducerMap> {
+	return function reduceInParallel ( state: Mapable, action: Action ): ReducerMap {
+		const sliceNames = Object.keys(reducerMap)
+
+		function reduceSlices (state: Mapable, sliceName: string): Mapable {
+			const sliceState = state[sliceName]
+			const reducer = reducerMap[sliceName]
+			const nextSliceState = reducer(sliceState, action)
+
+			if( nextSliceState == sliceState ) return state
+
+			return {
+				...state,
+				[sliceName]: nextSliceState
+			}
+		}
+
+		return sliceNames.reduce(reduceSlices, state)
+	}
+}
+
+function combineInSeries (...reducers: Reducer<any>[] ): Reducer<any> {
+	return function reduceInSeries ( state: Store, action: Action ): Store {
+		function reduceReducers (state: Store, reducer: Reducer<any>) {
+			return reducer(state, action)
+		}
+
+		return reducers.reduce(reduceReducers, state)
+	}
+}
+
+interface GetState {
+	(): Store
+}
+
+interface Listener {
+	(s: Store): void
+}
+
+export function createStore2 (
+	rootReducer: Reducer<any>
+): [GetState, Dispatch, Notify] {
+	let state: any
+	let subscriptions: Function[] = []
+
+	// interface ActionCreator {
+	// 	(a: string): Action
+	// }
+
+	// function bindToDispatch (actionCreator: ActionCreator) {
+	// 	const action = 
+	// 	return dispatch( actionCreator() )
+	// }
+
+	function dispatch(action: Action): void {
+		state = rootReducer(state, action)
+		subscriptions.forEach(subscripton => { subscripton(state) })
+	}
+
+	function getState (): Store {
+		return state
+	}
+
+	function notify (listener: Listener, shouldInvokeImmediate = true) {
+		const length = subscriptions.push(listener)
+
+		if( shouldInvokeImmediate ) {
+			listener(state)
+		}
+
+		return function () {
+			subscriptions = [
+				...subscriptions.slice(0, length - 1),
+				...subscriptions.slice(length)
+			]
+		}
+	}
+
+	return [getState, dispatch, notify]
+}
+
 // naive `composeReducers`/`useReducer`
 export function createStore (
 	reducerMap: ReducerMap
-): [Store, Dispatch, Notify] {
+): [Mapable, Dispatch, Notify] {
 	const init: Action = { type: 'STORE/INITIALISE' }
 	const sliceNames = Object.keys(reducerMap)
 
-	const store = sliceNames.reduce(getDefaultState, {} as Store)
+	const store = sliceNames.reduce(getDefaultState, {} as Mapable)
 	let subscriptions: Function[] = []
 
-	function getDefaultState (store: Object, sliceName: string): Object {
+	function getDefaultState (store: Mapable, sliceName: string): Mapable {
 		return {
 			...store,
 			[sliceName]: reducerMap[sliceName](undefined, init)


### PR DESCRIPTION
This resolves #24. Updates should happen in reducers (as we don't use OOP). Any reducer managing a game piece should respond to ticks, so we definitely need "slice" or parallel reducers. Some cases also require changes to multiple models, or a change in a flag (which is also held in the store) may lead to a change in a game piece as well. Examples of this include "if the left control is active, the ship should rotate this tick" and "if the game speed is X, modify a velocity by Y". This PR adds helpers for arranging reducers in the required shapes. It also adds some basic tests. I can see a use for this redux-like in other projects, so I'll begin the work to tighten it up. That means tests.